### PR TITLE
Add subscriptions and broadcast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,7 @@ twitter-stream = "^0.5.3"
 [dev-dependencies]
 percent-encoding = "1.0"
 serde_json = "1.0"
-serde = { version = "1.0", features = ["rc"] }
+
+[dev-dependencies.serde]
+features = ["rc"]
+version = "1.0"

--- a/examples/boss_list.rs
+++ b/examples/boss_list.rs
@@ -7,7 +7,7 @@ extern crate twitter_stream;
 extern crate petronel;
 
 use futures::{Future, Stream};
-use petronel::{Petronel, Token};
+use petronel::{EmptySubscriber, Petronel, Token};
 use petronel::error::*;
 use std::time::Duration;
 use tokio_core::reactor::{Core, Interval};
@@ -30,7 +30,7 @@ quick_main!(|| -> Result<()> {
 
     let stream = petronel::raid::RaidInfoStream::with_handle(&core.handle(), &token);
 
-    let (client, future) = Petronel::from_stream(stream, 20);
+    let (client, future) = Petronel::<u32, EmptySubscriber<_>>::from_stream(stream, 20);
 
     // Fetch boss list once per 5 seconds
     let interval = Interval::new(Duration::new(5, 0), &core.handle())

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -188,7 +188,8 @@ impl Service for PetronelServer {
             // TODO: Should this fail instead of returning 0?
             let id = req.remote_addr().map(|addr| addr.port()).unwrap_or(0);
 
-            let subscription = self.0.subscribe(name, id, Sender(sender));
+            let mut subscription = self.0.subscribe(id, Sender(sender));
+            subscription.follow(name);
 
             let body = Body {
                 body: chunks,

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -70,6 +70,7 @@ quick_main!(|| -> Result<()> {
     Ok(())
 });
 
+#[derive(Clone)]
 struct Sender(mpsc::Sender<hyper::Result<hyper::Chunk>>);
 
 impl<T> Subscriber<T> for Sender

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+pub trait Subscriber<T> {
+    fn send(&mut self, message: &T);
+}
+
+pub struct EmptySubscriber<T>(PhantomData<T>);
+impl<T> Subscriber<T> for EmptySubscriber<T> {
+    fn send(&mut self, _message: &T) {}
+}
+
+pub struct Broadcast<Id, S, T> {
+    subscribers: HashMap<Id, S>,
+    message_type: PhantomData<T>,
+}
+
+impl<Id, S, T> Broadcast<Id, S, T>
+where
+    Id: Ord + Hash,
+    S: Subscriber<T>,
+    T: Clone,
+{
+    pub fn new() -> Self {
+        Broadcast {
+            subscribers: HashMap::new(),
+            message_type: PhantomData,
+        }
+    }
+}
+
+impl<Id, S, T> Broadcast<Id, S, T>
+where
+    Id: Ord + Hash,
+{
+    pub fn is_empty(&self) -> bool {
+        self.subscribers.is_empty()
+    }
+
+    pub fn subscribe(&mut self, id: Id, subscriber: S) -> Option<S> {
+        self.subscribers.insert(id, subscriber)
+    }
+
+    pub fn unsubscribe(&mut self, id: Id) -> Option<S> {
+        self.subscribers.remove(&id)
+    }
+
+    pub fn send(&mut self, message: &T)
+    where
+        S: Subscriber<T>,
+    {
+        for subscriber in self.subscribers.values_mut() {
+            subscriber.send(message)
+        }
+    }
+}

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -18,7 +18,7 @@ pub struct Broadcast<Id, S, T> {
 
 impl<Id, S, T> Broadcast<Id, S, T>
 where
-    Id: Ord + Hash,
+    Id: Eq + Hash,
     S: Subscriber<T>,
     T: Clone,
 {
@@ -32,18 +32,22 @@ where
 
 impl<Id, S, T> Broadcast<Id, S, T>
 where
-    Id: Ord + Hash,
+    Id: Eq + Hash,
 {
     pub fn is_empty(&self) -> bool {
         self.subscribers.is_empty()
+    }
+
+    pub fn get(&self, id: &Id) -> Option<&S> {
+        self.subscribers.get(id)
     }
 
     pub fn subscribe(&mut self, id: Id, subscriber: S) -> Option<S> {
         self.subscribers.insert(id, subscriber)
     }
 
-    pub fn unsubscribe(&mut self, id: Id) -> Option<S> {
-        self.subscribers.remove(&id)
+    pub fn unsubscribe(&mut self, id: &Id) -> Option<S> {
+        self.subscribers.remove(id)
     }
 
     pub fn send(&mut self, message: &T)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,9 @@ extern crate twitter_stream;
 pub mod raid;
 pub mod error;
 mod petronel;
+mod broadcast;
 mod circular_buffer;
 
-pub use petronel::Petronel;
+pub use broadcast::{EmptySubscriber, Subscriber};
+pub use petronel::{Message, Petronel};
 pub use twitter_stream::Token;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,5 +21,5 @@ mod broadcast;
 mod circular_buffer;
 
 pub use broadcast::{EmptySubscriber, Subscriber};
-pub use petronel::{Message, Petronel};
+pub use petronel::{Message, Petronel, Subscription};
 pub use twitter_stream::Token;

--- a/src/petronel.rs
+++ b/src/petronel.rs
@@ -228,8 +228,17 @@ where
     fn unsubscribe(&mut self, boss_name: BossName, id: SubId) {
         if let Some(entry) = self.bosses.get_mut(&boss_name) {
             entry.broadcast.unsubscribe(id);
+        } else if let Entry::Occupied(mut entry) = self.requested_bosses.entry(boss_name) {
+            let is_empty = {
+                let broadcast = entry.get_mut();
+                broadcast.unsubscribe(id);
+                broadcast.is_empty()
+            };
+
+            if is_empty {
+                entry.remove();
+            }
         }
-        // TODO: If None, look up temporary broadcast
     }
 
     fn handle_raid_info(&mut self, info: RaidInfo) {


### PR DESCRIPTION
Added a `subscribe` method to `Petronel` which will return a
`Subscription` handler that can be used to follow bosses and receive
events. When the handler is dropped, the handler will automatically
unfollow all bosses and unregister itself.