### PR TITLE
Use ID pool for subscriber IDs

### DIFF
--- a/examples/boss_list.rs
+++ b/examples/boss_list.rs
@@ -30,7 +30,7 @@ quick_main!(|| -> Result<()> {
 
     let stream = petronel::raid::RaidInfoStream::with_handle(&core.handle(), &token);
 
-    let (client, future) = Petronel::<(), EmptySubscriber>::from_stream(stream, 20, |m| m);
+    let (client, future) = Petronel::<EmptySubscriber>::from_stream(stream, 20, |m| m);
 
     // Fetch boss list once per 5 seconds
     let interval = Interval::new(Duration::new(5, 0), &core.handle())

--- a/src/id_pool.rs
+++ b/src/id_pool.rs
@@ -31,7 +31,7 @@ impl IdPool {
     // This should never be called with `id` less than `max_id`
     pub fn recycle(&mut self, id: Id) {
         debug_assert!(id.0 <= self.max_id);
-        self.available.push(id)
+        self.available.push(id);
     }
 }
 

--- a/src/id_pool.rs
+++ b/src/id_pool.rs
@@ -1,7 +1,9 @@
-type Id = u32;
+#[derive(Clone, Hash, Debug, PartialEq, Eq)]
+pub struct Id(u32);
 
+#[derive(Debug)]
 pub struct IdPool {
-    max_id: Id,
+    max_id: u32,
     available: Vec<Id>,
 }
 
@@ -17,15 +19,18 @@ impl IdPool {
         self.available.pop().unwrap_or_else(|| {
             let id = self.max_id;
 
+            // This will panic when max_id is at u32's max value,
+            // but in practice, there would never be so many
+            // IDs being used at the same time.
             self.max_id += 1;
 
-            id
+            Id(id)
         })
     }
 
     // This should never be called with `id` less than `max_id`
-    pub fn push(&mut self, id: Id) {
-        debug_assert!(id <= self.max_id);
+    pub fn recycle(&mut self, id: Id) {
+        debug_assert!(id.0 <= self.max_id);
         self.available.push(id)
     }
 }
@@ -38,15 +43,15 @@ mod test {
     fn use_id() {
         let mut pool = IdPool::new();
 
-        assert_eq!(pool.get(), 0);
-        assert_eq!(pool.get(), 1);
-        assert_eq!(pool.get(), 2);
+        assert_eq!(pool.get(), Id(0));
+        assert_eq!(pool.get(), Id(1));
+        assert_eq!(pool.get(), Id(2));
 
-        pool.push(1);
-        pool.push(0);
-        assert_eq!(pool.get(), 0);
-        assert_eq!(pool.get(), 1);
-        assert_eq!(pool.get(), 3);
-        assert_eq!(pool.get(), 4);
+        pool.recycle(Id(1));
+        pool.recycle(Id(0));
+        assert_eq!(pool.get(), Id(0));
+        assert_eq!(pool.get(), Id(1));
+        assert_eq!(pool.get(), Id(3));
+        assert_eq!(pool.get(), Id(4));
     }
 }

--- a/src/id_pool.rs
+++ b/src/id_pool.rs
@@ -1,0 +1,52 @@
+type Id = u32;
+
+pub struct IdPool {
+    max_id: Id,
+    available: Vec<Id>,
+}
+
+impl IdPool {
+    pub fn new() -> Self {
+        IdPool {
+            max_id: 0,
+            available: Vec::new(),
+        }
+    }
+
+    pub fn get(&mut self) -> Id {
+        self.available.pop().unwrap_or_else(|| {
+            let id = self.max_id;
+
+            self.max_id += 1;
+
+            id
+        })
+    }
+
+    // This should never be called with `id` less than `max_id`
+    pub fn push(&mut self, id: Id) {
+        debug_assert!(id <= self.max_id);
+        self.available.push(id)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn use_id() {
+        let mut pool = IdPool::new();
+
+        assert_eq!(pool.get(), 0);
+        assert_eq!(pool.get(), 1);
+        assert_eq!(pool.get(), 2);
+
+        pool.push(1);
+        pool.push(0);
+        assert_eq!(pool.get(), 0);
+        assert_eq!(pool.get(), 1);
+        assert_eq!(pool.get(), 3);
+        assert_eq!(pool.get(), 4);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod model;
 pub mod raid;
 pub mod error;
 mod petronel;
+mod id_pool;
 mod broadcast;
 mod circular_buffer;
 


### PR DESCRIPTION
Generate subscriber IDs on demand, instead of requiring subscribers to
pass it in themselves. This is backed by an ID pool that recycles IDs as
subscriptions are dropped.