### PR TITLE
Refactor Message to use refs, add BossUpdate

### DIFF
--- a/examples/boss_list.rs
+++ b/examples/boss_list.rs
@@ -30,7 +30,7 @@ quick_main!(|| -> Result<()> {
 
     let stream = petronel::raid::RaidInfoStream::with_handle(&core.handle(), &token);
 
-    let (client, future) = Petronel::<EmptySubscriber>::from_stream(stream, 20, |m| m);
+    let (client, future) = Petronel::<EmptySubscriber>::from_stream(stream, 20, |_| ());
 
     // Fetch boss list once per 5 seconds
     let interval = Interval::new(Duration::new(5, 0), &core.handle())

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1,7 +1,6 @@
 use futures::Sink;
 use std::collections::HashMap;
 use std::hash::Hash;
-use std::marker::PhantomData;
 
 pub trait Subscriber {
     type Item;
@@ -37,11 +36,11 @@ where
 }
 
 #[derive(Clone, Debug)]
-pub struct EmptySubscriber<T = ::model::Message>(PhantomData<T>);
-impl<T> Subscriber for EmptySubscriber<T> {
-    type Item = T;
+pub struct EmptySubscriber;
+impl Subscriber for EmptySubscriber {
+    type Item = ();
 
-    fn send(&mut self, _message: &T) -> Result<(), ()> {
+    fn send(&mut self, _message: &Self::Item) -> Result<(), ()> {
         Ok(())
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,7 +2,6 @@ use chrono;
 use regex::Regex;
 use std::fmt;
 use std::ops::Deref;
-use std::sync::Arc;
 use string_cache::DefaultAtom;
 
 pub type DateTime = chrono::DateTime<chrono::Utc>;
@@ -17,9 +16,10 @@ lazy_static! {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
-pub enum Message {
+pub enum Message<'a> {
     Heartbeat,
-    Tweet(Arc<RaidTweet>),
+    Tweet(&'a RaidTweet),
+    BossUpdate(&'a RaidBoss),
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]


### PR DESCRIPTION
Since the messages will be transformed by the `map_message` function
immediately anyway, there's not much reason for it to be owned.