### PR TITLE
Change `map_message` to `filter_map_message`

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -61,19 +61,20 @@ quick_main!(|| -> Result<()> {
         ClientBuilder::from_hyper_client(&hyper_client, &token)
             .with_history_size(10)
             .with_subscriber::<Sender>()
-            .map_message(|msg| match msg {
-                Message::Heartbeat => "\n".into(),
+            .filter_map_message(|msg| match msg {
+                // Don't emit anything for heartbeat messages
+                Message::Heartbeat => None,
                 Message::TweetList(tweets) => {
                     let mut tweet_vec = tweets.to_vec();
                     tweet_vec.sort_by_key(|t| t.created_at);
                     let mut bytes = serde_json::to_vec(&tweet_vec).unwrap();
                     bytes.push(b'\n');
-                    bytes.into()
+                    Some(bytes.into())
                 }
                 other => {
                     let mut bytes = serde_json::to_vec(&other).unwrap();
                     bytes.push(b'\n');
-                    bytes.into()
+                    Some(bytes.into())
                 }
             })
             .build();

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -6,6 +6,13 @@ pub trait Subscriber {
     type Item;
 
     fn send(&mut self, message: &Self::Item) -> Result<(), ()>;
+    fn maybe_send(&mut self, message: Option<&Self::Item>) -> Result<(), ()> {
+        if let Some(msg) = message {
+            self.send(msg)
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl<S> Subscriber for S
@@ -69,6 +76,12 @@ where
 
     pub fn unsubscribe(&mut self, id: &Id) -> Option<S> {
         self.subscribers.remove(id)
+    }
+
+    pub(crate) fn maybe_send(&mut self, message: Option<&S::Item>) {
+        if let Some(msg) = message {
+            self.send(msg)
+        }
     }
 
     pub fn send(&mut self, message: &S::Item) {


### PR DESCRIPTION
Only send a message if `filter_map_message` returns `Some`. This allows
the end-user to ignore messages that they don't care about (such as
heartbeats, etc).