### PR TITLE
Export/import boss list

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -1,7 +1,7 @@
 use super::{AsyncResult, Event, Subscription};
 use futures::unsync::{mpsc, oneshot};
 use id_pool::Id as SubId;
-use model::{BossName, RaidBoss, RaidTweet};
+use model::{BossName, RaidBoss, RaidBossMetadata, RaidTweet};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -71,6 +71,10 @@ impl<Sub> Client<Sub> {
                 sender: tx,
             }
         })
+    }
+
+    pub fn export_metadata(&self) -> AsyncResult<Vec<RaidBossMetadata>> {
+        self.request(Event::ClientExportMetadata)
     }
 
     pub fn heartbeat(&self) {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,15 +13,9 @@ use futures::{Future, Poll};
 use futures::unsync::oneshot;
 use id_pool::Id as SubId;
 use image_hash::ImageHash;
-use model::{BossName, DateTime, RaidBoss, RaidTweet};
+use model::{BossName, DateTime, RaidBoss, RaidBossMetadata, RaidTweet};
 use raid::RaidInfo;
 use std::sync::Arc;
-
-pub(crate) struct RaidBossMetadata {
-    boss: RaidBoss,
-    last_seen: DateTime,
-    image_hash: Option<ImageHash>,
-}
 
 #[derive(Debug)]
 pub(crate) enum Event<Sub> {
@@ -49,6 +43,7 @@ pub(crate) enum Event<Sub> {
         boss_name: BossName,
         sender: oneshot::Sender<Vec<Arc<RaidTweet>>>,
     },
+    ClientExportMetadata(oneshot::Sender<Vec<RaidBossMetadata>>),
 
     ClientReadError,
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,7 +13,7 @@ use futures::{Future, Poll};
 use futures::unsync::oneshot;
 use id_pool::Id as SubId;
 use image_hash::ImageHash;
-use model::{BossName, DateTime, RaidBoss, RaidBossMetadata, RaidTweet};
+use model::{BossName, RaidBoss, RaidBossMetadata, RaidTweet};
 use raid::RaidInfo;
 use std::sync::Arc;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -8,8 +8,6 @@ pub use self::client::Client;
 pub use self::subscription::Subscription;
 pub use self::worker::Worker;
 
-use broadcast::Broadcast;
-use circular_buffer::CircularBuffer;
 use error::*;
 use futures::{Future, Poll};
 use futures::unsync::oneshot;
@@ -19,12 +17,10 @@ use model::{BossName, DateTime, RaidBoss, RaidTweet};
 use raid::RaidInfo;
 use std::sync::Arc;
 
-pub(crate) struct RaidBossEntry<Sub> {
+pub(crate) struct RaidBossMetadata {
     boss: RaidBoss,
     last_seen: DateTime,
     image_hash: Option<ImageHash>,
-    recent_tweets: CircularBuffer<Arc<RaidTweet>>,
-    broadcast: Broadcast<SubId, Sub>,
 }
 
 #[derive(Debug)]

--- a/src/client/worker.rs
+++ b/src/client/worker.rs
@@ -1,4 +1,4 @@
-use super::{Event, RaidBossMetadata, Subscription};
+use super::{Event, Subscription};
 use broadcast::{Broadcast, Subscriber};
 use circular_buffer::CircularBuffer;
 use error::*;
@@ -7,7 +7,7 @@ use futures::stream::{Map, OrElse, Select};
 use futures::unsync::mpsc;
 use id_pool::{Id as SubId, IdPool};
 use image_hash::{BossImageHash, ImageHash, ImageHashReceiver, ImageHashSender, ImageHasher};
-use model::{BossLevel, BossName, Message, RaidBoss, RaidTweet};
+use model::{BossLevel, BossName, Message, RaidBoss, RaidBossMetadata, RaidTweet};
 use raid::RaidInfo;
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry;
@@ -122,6 +122,11 @@ where
                 });
 
                 let _ = sender.send(tweets);
+            }
+            ClientExportMetadata(tx) => {
+                let _ = tx.send(Vec::from_iter(
+                    self.bosses.values().map(|e| e.boss_data.clone()),
+                ));
             }
             ClientReadError => {} // This should never happen
         }

--- a/src/client/worker.rs
+++ b/src/client/worker.rs
@@ -16,10 +16,10 @@ use std::sync::Arc;
 
 const DEFAULT_BOSS_LEVEL: BossLevel = 0;
 
-pub struct RaidBossEntry<Sub> {
-    boss_data: RaidBossMetadata,
-    recent_tweets: CircularBuffer<Arc<RaidTweet>>,
-    broadcast: Broadcast<SubId, Sub>,
+pub(crate) struct RaidBossEntry<Sub> {
+    pub(crate) boss_data: RaidBossMetadata,
+    pub(crate) recent_tweets: CircularBuffer<Arc<RaidTweet>>,
+    pub(crate) broadcast: Broadcast<SubId, Sub>,
 }
 
 #[must_use = "futures do nothing unless polled"]

--- a/src/image_hash/phash.rs
+++ b/src/image_hash/phash.rs
@@ -3,7 +3,7 @@ use image::{DynamicImage, FilterType};
 const SIZE: usize = 32;
 const SMALL_SIZE: usize = 8;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 pub struct ImageHash(u64);
 
 impl ImageHash {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,12 +1,12 @@
 use chrono;
-use image_hash::ImageHash;
+
+pub use image_hash::ImageHash;
 use regex::Regex;
 use std::collections::HashSet;
 use std::fmt;
 use std::ops::Deref;
 use std::sync::Arc;
 use string_cache::DefaultAtom;
-
 pub type DateTime = chrono::DateTime<chrono::Utc>;
 pub type TweetId = u64;
 pub type RaidId = String;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,5 @@
 use chrono;
+use image_hash::ImageHash;
 use regex::Regex;
 use std::collections::HashSet;
 use std::fmt;
@@ -36,6 +37,12 @@ pub struct RaidBoss {
     pub translations: HashSet<BossName>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RaidBossMetadata {
+    pub boss: RaidBoss,
+    pub last_seen: DateTime,
+    pub image_hash: Option<ImageHash>,
+}
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 pub struct BossName(DefaultAtom);


### PR DESCRIPTION
Add a way to preserve the boss list after restarts, by allowing 
import/export of boss metadata (boss, last seen, image hash)