### PR TITLE
Return stream error when Twitter stream completes

### DIFF
--- a/src/client/worker.rs
+++ b/src/client/worker.rs
@@ -3,7 +3,7 @@ use broadcast::{Broadcast, Subscriber};
 use circular_buffer::CircularBuffer;
 use error::*;
 use futures::{Async, Future, Poll, Stream};
-use futures::stream::{Map, OrElse, Select};
+use futures::stream::{Chain, Map, Once, OrElse, Select};
 use futures::unsync::mpsc;
 use id_pool::{Id as SubId, IdPool};
 use image_hash::{BossImageHash, ImageHash, ImageHashReceiver, ImageHashSender, ImageHasher};
@@ -33,7 +33,10 @@ where
     pub(crate) hash_requester: ImageHashSender,
     pub(crate) id_pool: IdPool,
     pub(crate) events: Select<
-        Map<S, fn(RaidInfo) -> Event<Sub, M::Export>>,
+        Map<
+            Chain<S, Once<RaidInfo, Error>>,
+            fn(RaidInfo) -> Event<Sub, M::Export>,
+        >,
         Select<
             OrElse<
                 mpsc::UnboundedReceiver<Event<Sub, M::Export>>,

--- a/src/raid.rs
+++ b/src/raid.rs
@@ -35,8 +35,8 @@ pub struct RaidInfoStream(FlattenStream<FutureTwitterStream>);
 // TODO: Add version that reconnects on disconnect/error
 impl RaidInfoStream {
     fn track() -> String {
-        // "Lv15,Lv20,Lv25,Lv30,...,Lv175,I need backup!Battle ID:"
-        let mut track = (3..35)
+        // "Lv15,Lv20,Lv25,Lv30,...,Lv200,I need backup!Battle ID:"
+        let mut track = (3..40)
             .map(|i| format!("Lv{}", i * 5))
             .collect::<Vec<_>>()
             .join(",");


### PR DESCRIPTION
If the Twitter stream ends, the worker should terminate since nothing
else will come through. It's up to the user of the library to determine
how to handle the error (usually by retrying the request and starting
another worker).