### PR TITLE
Update cached boss list on startup

### DIFF
--- a/src/client/worker.rs
+++ b/src/client/worker.rs
@@ -276,7 +276,7 @@ where
         }
     }
 
-    fn update_cached_boss_list(&mut self) {
+    pub(crate) fn update_cached_boss_list(&mut self) {
         let updated = self.bosses
             .values()
             .map(|entry| &entry.boss_data.boss)


### PR DESCRIPTION
If the worker starts with a list of bosses, the cached boss list should
be updated immediately (instead of using the default empty list).